### PR TITLE
Fix mkdocs deprecation issue and tidied mkdocs config

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,10 +1,13 @@
-site_name: AlexandriaDocs - Documentation
-site_description: AlexandriaDocs - Host for static generated documentation
-site_author: Sandro Rodrigues
-repo_url: https://github.com/srtab/alexandriadocs
-edit_uri: blob/master/docs
-pages:
-    - Home: index.md
+site_name:         AlexandriaDocs - Documentation
+site_description:  AlexandriaDocs - Host for static generated documentation
+
+site_author:       Sandro Rodrigues
+
+repo_url:          https://github.com/srtab/alexandriadocs
+edit_uri:          blob/master/docs
+
+nav:
+    - Home:        index.md
     - Accounts:
         - User permissions: accounts/permissions.md
     - Projects:


### PR DESCRIPTION
First of all, mkdocs has deprecated the `pages` option in favour of a new `nav` option so I've changed that in this PR.

Also, I've tidied up the configuration to be more readable.